### PR TITLE
Search for flow binary in node_modules paths

### DIFF
--- a/flow-mode.el
+++ b/flow-mode.el
@@ -29,8 +29,8 @@
 
 (defconst flow-buffer "*Flow Output*")
 
-(defcustom flow-binary "flow"
-  "Flow executable."
+(defcustom flow-default-binary "flow"
+  "Flow executable to use when no project-specific binary is found."
   :group 'flow-mode
   :type 'string)
 
@@ -61,21 +61,32 @@ POSITION point"
                 (flow-column-at-pos end)))
     ""))
 
+(defun flow-binary ()
+  (let* ((root (locate-dominating-file
+                (or (buffer-file-name) default-directory)
+                "node_modules"))
+         (flow (and root
+                    (expand-file-name "node_modules/.bin/flow"
+                                      root))))
+    (if (and flow (file-executable-p flow))
+        flow
+      flow-default-binary)))
+
 (defun flow-cmd (&rest args)
   "Run flow with arguments, outputs to flow buffer.
 ARGS"
-  (apply #'call-process flow-binary nil flow-buffer t args))
+  (apply #'call-process (flow-binary) nil flow-buffer t args))
 
 (defun flow-cmd-ignore-output (&rest args)
   "Run flow with arguments, ignore output.
 ARGS"
-  (apply #'call-process flow-binary nil nil nil args))
+  (apply #'call-process (flow-binary) nil nil nil args))
 
 (defun flow-cmd-to-string (&rest args)
   "Run flow with arguments, outputs to string.
 ARGS"
   (with-temp-buffer
-    (apply #'call-process flow-binary nil t nil args)
+    (apply #'call-process (flow-binary) nil t nil args)
     (buffer-string)))
 
 (defmacro flow-with-flow (&rest body)
@@ -180,7 +191,7 @@ BODY progn"
 
 (defun flow-stop-flow-server ()
   "Stop flow hook."
-  (if flow-stop-server-on-exit (flow-cmd-ignore-output "stop")))
+  (if flow-stop-server-on-exit (ignore-errors (flow-cmd-ignore-output "stop"))))
 
 (add-hook 'kill-emacs-hook 'flow-stop-flow-server t)
 


### PR DESCRIPTION
I've noticed that most projects that I use don't use a globally-installed `flow` binary but one that lives in node_modules at the project root; hence, this change: It makes `flow-binary` into a function that searches in the project first, then will fall back onto `flow-default-binary`.

I hope this rename isn't a problem for whoever has installed flow-mode already; I thought I'd submit this first to test the waters. But we can also put more thought into the naming here, to remain more backwards compatible.