### PR TITLE
Recognize '// @flow' tag even after other comments

### DIFF
--- a/flow-minor-mode.el
+++ b/flow-minor-mode.el
@@ -210,8 +210,23 @@ BODY progn"
   "Return true if the '// @flow' tag is present in the current buffer."
   (save-excursion
     (goto-char (point-min))
-    (or (looking-at "//+[ ]*@flow")
-        (looking-at "/\\**[ ]*@flow"))))
+    (let (stop found)
+      (while (not stop)
+        (when (not (re-search-forward "[^\n[:space:]]" nil t))
+          (setq stop t))
+        (backward-char)
+
+        (cond ((or (looking-at "//+[ ]*@flow")
+                   (looking-at "/\\**[ ]*@flow"))
+               (setq found t)
+               (setq stop t))
+              ((looking-at "//")
+               (forward-line))
+              ((looking-at "/\\*")
+               (when (not (re-search-forward "*/" nil t))
+                 (setq stop t)))
+              (t (setq stop t))))
+      found)))
 
 (defun flow-minor-configured-p ()
   "Predicate to check configuration."


### PR DESCRIPTION
The `// @flow` tag is currently only recognized if it is the first thing in the buffer. Flow documentation states that it only has to be before any actual code in order to be recognized. I work with code that has block comments before the tag, and this PR will ignore any comments before the tag.

I don't think the code I've done in the PR look very nice, so I'd be happy to be learn how it can be improved.