### PR TITLE
add flow-status command, run like M-x compile

### DIFF
--- a/flow-minor-mode.el
+++ b/flow-minor-mode.el
@@ -30,6 +30,7 @@
 
 (require 'xref)
 (require 'json)
+(require 'compile)
 
 (defconst flow-minor-buffer "*Flow Output*")
 
@@ -304,6 +305,16 @@ BODY progn"
   (when (and (flow-minor-configured-p)
              (flow-minor-tag-present-p))
     (flow-minor-mode +1)))
+
+(defun flow-status ()
+  "Invoke flow to check types"
+  (interactive)
+  (let ((cmd "flow status")
+        (regexp '(flow "^\\(Error:\\)[ \t]+\\(\\(.+\\):\\([[:digit:]]+\\)\\)"
+                       3 4 nil (1) 2 (1 compilation-error-face))))
+    (add-to-list 'compilation-error-regexp-alist 'flow)
+    (add-to-list 'compilation-error-regexp-alist-alist regexp)
+    (compile cmd)))
 
 (provide 'flow-minor-mode)
 ;;; flow-minor-mode.el ends here


### PR DESCRIPTION
I would like to add `M-x flow-status`, which works with `compilation-mode` just like `M-x compile`. and it used the very same output of `flow status` (wish flow has a flag `--show-file-path`)

Here recaptures few `compilation-mode` usages: 
1. a user can goto the next Error (the line of its file) with <code>M-`</code> or  
2. goto a specific Error with key `enter` when the cursor is inside the compilation-mode buffer.
3. press `g` in compilation-mode to rerun `flow status`

Here is a screen capture:

![demo](https://user-images.githubusercontent.com/13225610/33449917-04e7e4d8-d5bf-11e7-9553-2f197f0e6cc8.gif)
