### PR TITLE
Remove not needed when-let usage

### DIFF
--- a/flow-minor-mode.el
+++ b/flow-minor-mode.el
@@ -220,7 +220,7 @@ BODY progn"
 (add-hook 'kill-emacs-hook 'flow-minor-stop-flow-server t)
 
 (defun flow-minor-maybe-delete-process (name)
-  (when-let (process (get-process name))
+  (when (get-process name)
     (delete-process name)))
 
 (defun flow-minor-eldoc-sentinel (process _event)


### PR DESCRIPTION
This is actually not required because the function is not doing
anything with `process`. Also, `when-let` is deprecated on Emacs 26+
fixing compatibility issues with Emacs 26.