### PR TITLE
Use (flow-minor-binary) when invoking flow status

### DIFF
--- a/flow-minor-mode.el
+++ b/flow-minor-mode.el
@@ -311,7 +311,7 @@ BODY progn"
 (defun flow-status ()
   "Invoke flow to check types"
   (interactive)
-  (let ((cmd "flow status")
+  (let ((cmd (concat (flow-minor-binary) " status"))
         (regexp '(flow "^\\(Error:\\)[ \t]+\\(\\(.+\\):\\([[:digit:]]+\\)\\)"
                        3 4 nil (1) 2 (1 compilation-error-face))))
     (add-to-list 'compilation-error-regexp-alist 'flow)


### PR DESCRIPTION
I didn't have flow in my path and so flow status was erroring out on me.  This change uses the "discovered" binary for "flow status" the way the other parts of the code does.