### PR TITLE
Show a multiline type

### DIFF
--- a/flow-minor-mode.el
+++ b/flow-minor-mode.el
@@ -156,6 +156,8 @@ BODY progn"
     (flow-minor-colorize-buffer)
     (buffer-string)))
 
+(defvar flow-minor-pos-regexp "\n\\(.*:[0-9]+:[0-9]+.*\n\\)?\\'")
+
 (defun flow-minor-type-at-pos ()
   "Show type at position."
   (interactive)
@@ -164,7 +166,8 @@ BODY progn"
           (line (number-to-string (line-number-at-pos)))
           (col (number-to-string (1+ (current-column))))
           (type (flow-minor-cmd-to-string "type-at-pos" "--quiet" file line col)))
-     (message "%s" (flow-minor-colorize-type (car (split-string type "\n")))))))
+     (message "%s" (flow-minor-colorize-type
+                    (replace-regexp-in-string flow-minor-pos-regexp "" type))))))
 
 (defun flow-minor-jump-to-definition ()
   "Jump to definition."
@@ -228,10 +231,11 @@ BODY progn"
     (if (eq (process-exit-status process) 0)
         (with-current-buffer "*Flow Eldoc*"
           (goto-char (point-min))
-          (forward-line 1)
-          (delete-region (point) (point-max))
+          (save-match-data
+            (if (re-search-forward flow-minor-pos-regexp nil t)
+                (replace-match "")))
           (flow-minor-colorize-buffer)
-          (eldoc-message (car (split-string (buffer-substring (point-min) (point-max)) "\n")))))))
+          (eldoc-message (buffer-string))))))
 
 (defun flow-minor-eldoc-documentation-function ()
   "Display type at point with eldoc."

--- a/flow-minor-mode.el
+++ b/flow-minor-mode.el
@@ -163,7 +163,7 @@ BODY progn"
    (let* ((file (buffer-file-name))
           (line (number-to-string (line-number-at-pos)))
           (col (number-to-string (1+ (current-column))))
-          (type (flow-minor-cmd-to-string "type-at-pos" file line col)))
+          (type (flow-minor-cmd-to-string "type-at-pos" "--quiet" file line col)))
      (message "%s" (flow-minor-colorize-type (car (split-string type "\n")))))))
 
 (defun flow-minor-jump-to-definition ()
@@ -174,7 +174,7 @@ BODY progn"
           (line (number-to-string (line-number-at-pos)))
           (col (number-to-string (1+ (current-column))))
           (location (json-read-from-string
-                     (flow-minor-cmd-to-string "get-def" "--json" file line col)))
+                     (flow-minor-cmd-to-string "get-def" "--json" "--quiet" file line col)))
           (path (alist-get 'path location))
           (line (alist-get 'line location))
           (offset-in-line (alist-get 'start location)))
@@ -244,6 +244,7 @@ BODY progn"
          (command (list (flow-minor-binary)
                         "type-at-pos"
                         "--path" buffer-file-name
+                        "--quiet"
                         (number-to-string line)
                         (number-to-string col)))
          (process (make-process :name "flow-minor-eldoc"


### PR DESCRIPTION
Currently flow-minor-mode only shows the first line of a type-at-pos output, but a type representation may contain more than one line when a type does not fit in a line.

```
% node_modules/.bin/flow type-at-pos /path/to/Tweet.jsx 12 52
type Props = {
  body: string,
  children?: Node,
  hashtags: Array<string>,
  url: string,
  ...
}
/path/to/Tweet.jsx:12:52,12:56
```

In this case, you could only see `type Props = {`.  This PR fixes the problem.